### PR TITLE
Remove orphaned reference to merge composition operation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7222,14 +7222,6 @@ new SeqGroup(
             the <a>animation effect</a> is <a title="addition">added</a> to
             <a>base value</a> it is combined with.
           </dd>
-          <dt>merge</dt>
-          <dd>
-            Corresponds to the <a
-            title="composition operation merge">merge</a>
-            <a>composition operation</a> value such that
-            the <a>animation effect</a> is combined with its <a>base value</a>
-            in a time-dependent fashion.
-          </dd>
         </dl>
       </section>
       <section>


### PR DESCRIPTION
Merge composition was removed in https://dvcs.w3.org/hg/FXTF/rev/40165bac62ab
