### PR TITLE
Fix procedure for evenly distributing keyframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3641,42 +3641,18 @@
         <ol>
           <li>Let <var>distributed keyframes</var> be a copy of <var>initial
               keyframe list</var>.
-          <li>If there is no <a>keyframe</a> in <var>distributed keyframes</var>
-              with a <a title="positional offset of a keyframe">positional
-              offset</a> of 0, then,
-            <dl class="switch">
-              <dt>If there is more than one <a>keyframe</a> in <var>distributed
-                  keyframes</var> and the first <a>keyframe</a> does not have
-                  a specified positional offset,</dt>
-              <dd>
-                Set the positional offset of the first <a>keyframe</a> in
-                <var>distributed keyframes</var> to 0.
-              </dd>
-              <dt>Otherwise,</dt>
-              <dd>
-                Temporarily add an empty <a>keyframe</a> to the
-                start of <var>distributed keyframes</a> with a positional
-                offset of 0.
-              </dd>
-            </dl>
-          <li>Likewise, if there is no <a>keyframe</a> in <var>distributed
-              keyframes</var> with a <a
+          <li>If <var>distributed keyframes</var> constains more than one
+              <a>keyframe</a> and the <a
               title="positional offset of a keyframe">positional offset</a> of
-              1, then,
-            <dl class="switch">
-              <dt>If <var>distributed keyframes</var> is not empty and the last
-                  <a>keyframe</a> does not have a specified positional
-                  offset,</dt>
-              <dd>
-                Set the positional offset of the last <a>keyframe</a> in
-                <var>distributed keyframes</var> to 1.
-              </dd>
-              <dt>Otherwise,</dt>
-              <dd>
-                Temporarily append an empty <a>keyframe</a> to the end of
-                <var>distributed keyframes</a> with a positional offset of 1.
-              </dd>
-            </dl>
+              the first <a>keyframe</a> in <var>distributed keyframes</var> is
+              unspecified, set its <a
+              title="positional offset of a keyframe">positional offset</a> to
+              0.
+          <li>If the <a title="positional offset of a keyframe">positional
+              offset</a> of the last <a>keyframe</a> in <var>distributed
+              keyframes</var> is unspecified, set its <a
+              title="positional offset of a keyframe">positional offset</a> to
+              1.
           <li>Set the offset of all <a>keyframes</a> in <var>distributed
               keyframes</var> without a specified <a
               title="positional offset of a keyframe">positional offset</a> as
@@ -3702,9 +3678,6 @@
                 * <var>i</var>
                 / (<var>n</var> + 1)</code>
               </p>
-          <li>If any temporary keyframes were added to <var>distributed
-              keyframes</var> in steps 1 or 2, remove them from <var>distributed
-              keyframes</var>.
           <li>Return <var>distributed keyframes</var>.
         </ol>
       </section>


### PR DESCRIPTION
Steps 2 and 3 of the existing algorithm ensure that offsets are specified for
the (perhaps temporary) first and last keyframes only if there are no keyframes
present with offsets of 0 and 1 respectively. This means that if keyframes with
offsets of 0 and 1 are present, but the first or last keyframes lack specified
offsets, step 4 will fail.

This patch fixes this bug by always ensuring that the first and last keyframes
have specified offsets, so that step 4 can assign offsets to any interior
keyframes with unspecified offsets.

This patch also removes the use of temporary keyframes. These are not required,
as if the last first or last keyframes already have specified offsets, no
interpolation to calculate offsets is required.
