### PR TITLE
Remove logic from keyframe list normalization for multiple values for a single property

### DIFF
--- a/index.html
+++ b/index.html
@@ -7331,9 +7331,6 @@ new SeqGroup(
                 class="sectionRef"></a>.
             <li>Remove all property values in <var>normalized keyframes</var>
                 that are invalid or not supported by the implementation.
-            <li>For each <a>keyframe</a> in <var>normalized keyframes</var>,
-                if there are two or more properties for the same property,
-                remove all but the last property value for each property.
             <li>Return <var>normalized keyframes</var>.
           </ol>
           <div class="note">


### PR DESCRIPTION
With the current keyframe syntax, it's not possible to specify multiple values for
a single property.
