### PR TITLE
Remove text for handling 'non interpolable' values

### DIFF
--- a/index.html
+++ b/index.html
@@ -3527,14 +3527,6 @@
           <li>Let <var>end keyframe</var> be the next <a>keyframe</a> in
               <var>property-specific keyframes</var> after <var>start
               keyframe</var>.</li>
-          <li>If the pair of property values specified by <var>start
-              keyframe</var> and <var>end keyframe</var>
-              differ in <a>property type</a> or have the same <a>property
-              type</a> but that type is not <a>interpolable</a>,
-              then return the property value of <var>start keyframe</var>
-              unless <var>time fraction</var> is greater than or equal to 1, in
-              which case return the property value of <var>end
-              keyframe</var>.</li>
           <li>Let <var>start offset</var> be the positional offset of <var>start
               keyframe</var>.</li>
           <li>Let <var>end offset</var> be the offset of <var>end


### PR DESCRIPTION
Now that we define interpolation and addition for all property value types, the
algorithm for evaluating a keyframe animation effect should no longer
explicitly handle types which are 'not interpolable'.
