### PR TITLE
Fix default addition procedure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4355,35 +4355,36 @@
           used.
         </p>
         <p>
-          Note that the neutral value does not match any value 
-          type and thus all calculations involving the neutral value will 
-          use the default algorithms.
-        </p>
-        <div class="issue">
-          What is this neutral value? We have the <a>neutral value for
-          composition</a> but that has a specific meaning and addition procedure
-          defined where it is used.
-        </div>
-        <p>
-        Given the output <i>p</i> of a timing function, the result
-        <var>V<sub>res</sub></var> of interpolating between two values,
-        <var>V<sub>start</sub></var> and <var>V<sub>end</sub></var> is given by
-         <blockquote>
-          <dl class="switch">
-            <dt>If 0 &le; <i>p</i> &lt; 0.5</dt>
-            <dd><var>V<sub>res</sub></var> = <var>V<sub>start</sub></var></dd>
-            <dt>Otherwise,</dt>
-            <dd><var>V<sub>res</sub></var> = <var>V<sub>end</sub></var></dd>
-          </dl>
-         </blockquote>
-         Note that interpolation is never performed on invalid values.
+          Note that the <a>neutral value for composition</a> does not match
+          any value type and thus all calculations involving the <a>neutral
+          value for composition</a> will use the default algorithms.
         </p>
         <p>
-          Addition is between two values <var>V<sub>a</sub></var> and 
-          <var>V<sub>b</sub></var>. The result <var>V<sub>res</sub></var> is given by 
-         <blockquote>
-            <var>V<sub>res</sub></var> = <var>V<sub>a</sub></var> + <var>V<sub>a</sub></var> 
-         </blockquote>
+          Given the output <i>p</i> of a timing function, the result
+          <var>V<sub>res</sub></var> of interpolating between two values,
+          <var>V<sub>start</sub></var> and <var>V<sub>end</sub></var> is given by
+          <blockquote>
+            <dl class="switch">
+              <dt>If 0 &le; <i>p</i> &lt; 0.5</dt>
+              <dd><var>V<sub>res</sub></var> = <var>V<sub>start</sub></var></dd>
+              <dt>Otherwise,</dt>
+              <dd><var>V<sub>res</sub></var> = <var>V<sub>end</sub></var></dd>
+            </dl>
+          </blockquote>
+          Note that interpolation is never performed on invalid values.
+        </p>
+        <p>
+          Addition is between two values <i>V</i><sub>a</sub> and 
+          <i>V</i><sub>b</sub>. The result <i>V</i><sub>res</sub> is given by 
+          <blockquote>
+            <i>V</i><sub>res</sub> = <i>V</i><sub>b</sub> 
+          </blockquote>
+          unless <i>V</i><sub>b</sub> is the <a>neutral value for
+          composition</a>, in which case
+          <blockquote>
+            <i>V</i><sub>res</sub> = <i>V</i><sub>a</sub>
+          </blockquote>
+        </p>
       </section>
     </section>
 


### PR DESCRIPTION
The default addition operation should be to take the right operand, unless it's
the neutral value, in which case it should take the left operand.
