### PR TITLE
Add accumulate argument to PathAnimationEffect constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -7462,6 +7462,11 @@ elem.animate({ left: '100px' }, 3);
                 animation with the <a>animation stack</a>, as specified by one
                 of the <a>CompositeOperation</a> enumeration values.
               </dd>
+              <dt>optional AccumulateOperation accumulate = "none"</dt>
+              <dd>
+                The <a>accumulation operation</a> used to define the way
+                animation values build from iteration to iteration.
+              </dd>
             </dl>
           </dd>
           <dt>attribute SVGPathSegList segments</dt>


### PR DESCRIPTION
Currently, the description of a path animation effect includes the accumulate
property, and it the accumulate property is present as an attribute on the
AnimationEffect interface, but there is no way to set it through the API.
