### PR TITLE
Remove superfluous text for transformed time with iteration duration zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -3477,9 +3477,7 @@
               </dt>
               <dd>
                 Return the result of recalculating the <a>transformed time</a>
-                using a <a>local time</a> less than <a>start delay</a> (e.g.
-                <code><a>start delay</a> - 1</code>) and an <a>iteration
-                duration</a> of 1.
+                using a <a>iteration duration</a> of 1.
               </dd>
               <dt>
                 Otherwise,


### PR DESCRIPTION
This spec currently includes the following text ...

'If local time < start delay, Return the result of recalculating the
transformed time using a local time less than start delay (e.g.
start delay - 1)'

The text 'using a local time less than start delay' is superfluous, as the
local time is already known to meet to meet this condition. Furthermore, using
'start delay - 1' as suggested can cause problems due to floating point
inaccuracies.

This patch simply removes the superfluous text.

Note that this text was added in c394adf7c659133f01c9bb6893f97025cbd2d1ec
