### PR TITLE
Fix the transformed time when the iteration duration is infinity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3072,10 +3072,10 @@
           <a>directed time</a> using the following steps:
         </p>
         <ol>
-          <li>
-            If the <a>directed time</a> is <code>null</code>,
-            return <code>null</code>.
-          </li>
+          <li>If the <a>directed time</a> is <code>null</code>, return
+              <code>null</code>.</li>
+          <li>If the <a>iteration duration</a> is infinity, return the
+              <a>directed time</a>.</li>
           <li>Let <var>iteration fraction</var> be the result of
               evaluating <code><a>directed time</a> / <a>iteration
               duration</a></code> unless <a>iteration duration</a> is


### PR DESCRIPTION
A group should pass a non-zero transformed time to its children whenever its
directed time is non-zero, even if its iteration duration is infinite.
Currently, however, such a TimedItem always has a zero transformed time,
because this is calculated from the iteration fraction, which is always zero
when the iteration duration is infinity.

This change fixes the problem by bypassing the iteration fraction in this case
and setting the transformed time to the directed time.
