### PR TITLE
Temporary workaround for <pre> inside <div>.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -5215,11 +5215,9 @@ interface AnimationNode {
         Note that this definition precludes the following usage since
         <code>node</code> is an <a>inclusive ancestor</a> of itself:
 
-        FIXME: pre needs to work in lists.
-
-        <div class="example sh_javascript">
-            node.before(node); // throws HierarchyRequestError
-        </div>
+        <div><pre class="example sh_javascript">
+        node.before(node); // throws HierarchyRequestError
+        </pre></div>
     </div>
 
 :   <dfn method for=AnimationNode title='after()'>
@@ -6268,16 +6266,16 @@ interface Animatable {
 
     The following code fragment:
 
-    FIXME: <div class="example sh_javascript">
+    <div><pre class="example sh_javascript">
     var anim = elem.animate({ opacity: 0 }, 2000);
-    </div>
+    </pre></div>
 
     is equivalent to:
 
-    FIXME: <div class="example sh_javascript">
+    <div><pre class="example sh_javascript">
     var anim = new Animation(elem, { opacity: 0 }, 2000);
     elem.ownerDocument.timeline.play(anim);
-    </div>
+    </pre></div>
 
     Returns the {{AnimationPlayer}} object returned by the
     <code>play</code> method of the {{AnimationTimeline}}.
@@ -7244,12 +7242,11 @@ the Web Animations model is as follows:
     animation's <code>startTime</code> will reflect updated state of
     the model immediately.
 
-    FIXME: <div class="example sh_javascript">
+    <div><pre class="example sh_javascript">
       // Initially player.src.localTime is 3000
       player.currentTime += 2000;
       alert(player.src.localTime); // Displays &lsquo;5000&rsquo;
-
-    </div>
+    </pre></div>
 
     The same concept applies to more complex modifications of the
     Web Animations model such as adding and removing children from
@@ -7270,24 +7267,22 @@ the Web Animations model is as follows:
     element, the result of the new animation will be
     incorporated in the value returned.
 
-    FIXME: <div class="example sh_javascript">
-      // Set opacity to 0 immediately
-      elem.animate({ opacity: 0 }, { fill: &lsquo;forwards&rsquo; });
-      alert(window.getComputedStyle(elem).opacity); // Displays &lsquo;0&rsquo;
-
-    </div>
+    <div><pre class="example sh_javascript">
+    // Set opacity to 0 immediately
+    elem.animate({ opacity: 0 }, { fill: &lsquo;forwards&rsquo; });
+    alert(window.getComputedStyle(elem).opacity); // Displays &lsquo;0&rsquo;
+    </pre></div>
 
     The means of querying the animated value of an attribute depends
     on the interface defined for the attribute.
     SVG 1.1 [[!SVG11]] defines an additional interface for querying
     animated values.
 
-    FIXME: <div class="example sh_javascript">
-      // Set width to 0 immediately
-      rect.animate({ width: &lsquo;100px&rsquo; }, { fill: &lsquo;forwards&rsquo; });
-      alert(rect.width.animVal.value); // Displays &lsquo;100&rsquo;
-
-    </div>
+    <div><pre class="example sh_javascript">
+    // Set width to 0 immediately
+    rect.animate({ width: &lsquo;100px&rsquo; }, { fill: &lsquo;forwards&rsquo; });
+    alert(rect.width.animVal.value); // Displays &lsquo;100&rsquo;
+    </pre></div>
 
     </div>
 
@@ -7301,14 +7296,13 @@ the Web Animations model is as follows:
     not be called until <em>after</em> the script block has
     completed during regular sampling.
 
-    FIXME: <div class="example sh_javascript">
-      var timesCalled = 0;
-      elem.animate(function() {
-        timesCalled++;
-      }, 10000);
-      alert(timesCalled); // Displays &lsquo;0&rsquo;
-
-    </div>
+    <div><pre class="example sh_javascript">
+    var timesCalled = 0;
+    elem.animate(function() {
+      timesCalled++;
+    }, 10000);
+    alert(timesCalled); // Displays &lsquo;0&rsquo;
+    </pre></div>
 
     </div>
 
@@ -7327,13 +7321,12 @@ the Web Animations model is as follows:
     a situation where <em>only</em> the change to specified style is
     rendered without the animation.
 
-    FIXME: <div class="example sh_javascript">
-      // Fade the opacity with fallback for browsers that don't
-      // support Element.animate
-      elem.style.opacity = &lsquo;0&rqsuo;
-      elem.animate([ { opacity: 1 }, { opacity: 0 } ], 500);
-
-    </div>
+    <div><pre class="example sh_javascript">
+    // Fade the opacity with fallback for browsers that don't
+    // support Element.animate
+    elem.style.opacity = &lsquo;0&rqsuo;
+    elem.animate([ { opacity: 1 }, { opacity: 0 } ], 500);
+    </pre></div>
 
     Note that a user agent may render a frame with <em>none</em> of
     the changes made in a script execution block.
@@ -7353,13 +7346,12 @@ the Web Animations model is as follows:
     a long block of code that is executed in the same script block
     will return the same value as shown in the following example.
 
-    FIXME: <div class="example sh_javascript">
-      var a = document.timeline.currentTime;
-      // ... many lines of code ...
-      var b = document.timeline.currentTime;
-      alert(b - a); // Displays 0
-
-    </div>
+    <div><pre class="example sh_javascript">
+    var a = document.timeline.currentTime;
+    // ... many lines of code ...
+    var b = document.timeline.currentTime;
+    alert(b - a); // Displays 0
+    </pre></div>
 
     </div>
 
@@ -7395,13 +7387,12 @@ the Web Animations model is as follows:
     a <code>requestAnimationFrame</code> callback acts as
     an alias for <code>document.timeline.currentTime</code>.
 
-    FIXME: <div class="example sh_javascript">
-      window.requestAnimationFrame(function(sampleTime) {
-        // Displays &lsquo;0&rsquo;
-        alert(sampleTime - document.timeline.currentTime);
-      });
-
-    </div>
+    <div><pre class="example sh_javascript">
+    window.requestAnimationFrame(function(sampleTime) {
+      // Displays &lsquo;0&rsquo;
+      alert(sampleTime - document.timeline.currentTime);
+    });
+    </pre></div>
 
     </div>
 


### PR DESCRIPTION
This gets all our code examples inside lists looking right again.
