### PR TITLE
Consistent commas for cubic-bezier

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2511,7 +2511,7 @@ The meaning of each value is as follows:
 ::  Equivalent to cubic-bezier(0, 0, 0.58, 1).
 :   ease-in-out
 ::  Equivalent to cubic-bezier(0.42, 0, 0.58, 1).
-:   cubic-bezier(&lt;number&gt; &lt;number&gt; &lt;number&gt; &lt;number&gt;)
+:   cubic-bezier(&lt;number&gt;, &lt;number&gt;, &lt;number&gt;, &lt;number&gt;)
 ::  Specifies a <a>cubic B&eacute;zier timing function</a>.
     The four numbers specify points <var>P1</var> and <var>P2</var> of
     the curve as (x1, y1, x2, y2).


### PR DESCRIPTION
cubic-bezier is now consistently described as accepting a
comma-delimited list of four numbers.
