### PR TITLE
Update specification to match state of bikeshed at head

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -4043,16 +4043,12 @@ procedure.
                 [<var>paced A</var>, <var>k</var>].
             2.  Set the offset of <var>k</var> to
                 <a title="offsetk">offset</a><sub><var>paced
-                  A</var></sub>
-                +
+                  A</var></sub> +
                 (<a title="offsetk">offset</a><sub><var>paced
-                  B</var></sub>
-                &minus;
+                  B</var></sub> &minus;
                 <a title="offsetk">offset</a><sub><var>paced
-                  A</var></sub>)
-                &times;
-                <a title="distk">dist</a><sub><var>k</var></sub>
-                /
+                  A</var></sub>) &times;
+                <a title="distk">dist</a><sub><var>k</var></sub> /
                 <a title="distk">dist</a><sub><var>paced
                   B</var></sub>
         7.  For each keyframe in the range (<var>paced A</var>,
@@ -5483,7 +5479,7 @@ dictionary ComputedTimingProperties : AnimationTimingProperties {
 
 <div class='attributes'>
 
-:   <dfn attribute for=ComputedTimingProperties>startTime</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>startTime</dfn>
     <span member-info for=ComputedTimingProperties/startTime></span>
 ::  The <a title='animation node start time'>start time</a> of this
     <a>animation node</a> in milliseconds.
@@ -5497,7 +5493,7 @@ dictionary ComputedTimingProperties : AnimationTimingProperties {
     the <a title="animation node start time">start time</a> and
     <a>start delay</a>.
 
-:   <dfn attribute for=ComputedTimingProperties>endTime</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>endTime</dfn>
     <span member-info for=ComputedTimingProperties/endTime></span>
 ::  The <a>end time</a> of the <a>animation node</a> expressed in
     milliseconds in <a title="inherited time">inherited time
@@ -5505,11 +5501,11 @@ dictionary ComputedTimingProperties : AnimationTimingProperties {
     This corresponds to the end of the <a>animation node</a>'s active
     interval plus any <a>end delay</a>.
 
-:   <dfn attribute for=ComputedTimingProperties>activeDuration</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>activeDuration</dfn>
     <span member-info for=ComputedTimingProperties/activeDuration></span>
 ::  The <a>active duration</a> of this <a>animation node</a>.
 
-:   <dfn attribute for=ComputedTimingProperties>localTime</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>localTime</dfn>
     <span member-info for=ComputedTimingProperties/localTime></span>
 ::  The <a>local time</a> of this <a>animation node</a>.
 
@@ -5518,11 +5514,11 @@ dictionary ComputedTimingProperties : AnimationTimingProperties {
     it has a <a>parent animation group</a> that is not <a>in
     effect</a>.
 
-:   <dfn attribute for=ComputedTimingProperties>timeFraction</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>timeFraction</dfn>
     <span member-info for=ComputedTimingProperties/timeFraction></span>
 ::  The current <a>time fraction</a> of this <a>animation node</a>.
 
-:   <dfn attribute for=ComputedTimingProperties>currentIteration</dfn>
+:   <dfn dict-member for=ComputedTimingProperties>currentIteration</dfn>
     <span member-info for=ComputedTimingProperties/currentIteration></span>
 ::  The <a>current iteration</a> index beginning with zero for the first
     iteration.
@@ -5558,47 +5554,47 @@ dictionary AnimationTimingProperties {
 
 <div class='attributes'>
 
-:   <dfn attribute for=AnimationTimingProperties>delay</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>delay</dfn>
     <span member-info for=AnimationTimingProperties/delay></span>
 ::  The specified <a>start delay</a>.
 
     See the description of the <code>delay</code> attribute on
     the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>endDelay</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>endDelay</dfn>
     <span member-info for=AnimationTimingProperties/endDelay></span>
 ::  The specified <a>end delay</a>.
 
     See the description of the <code>endDelay</code> attribute on
     the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>fill</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>fill</dfn>
     <span member-info for=AnimationTimingProperties/fill></span>
 ::  The <a>fill mode</a> as specified by one of the <a enum>FillMode</a>
     enumeration values.
 
-:   <dfn attribute for=AnimationTimingProperties>iterationStart</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>iterationStart</dfn>
     <span member-info for=AnimationTimingProperties/iterationStart></span>
 ::  The <a>animation node</a>'s <a>iteration start</a> property.
 
     See the description of the <code>iterationStart</code> attribute
     on the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>iterations</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>iterations</dfn>
     <span member-info for=AnimationTimingProperties/iterations></span>
 ::  The <a>animation node</a>'s <a>iteration count</a> property.
 
     See the description of the <code>iterations</code> attribute
     on the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>duration</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>duration</dfn>
     <span member-info for=AnimationTimingProperties/duration></span>
 ::  The <a>iteration duration</a> of the <a>animation node</a>.
 
     See the description of the <code>duration</code>
     attribute on the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>playbackRate</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>playbackRate</dfn>
     <span member-info for=AnimationTimingProperties/playbackRate></span>
 ::  The <a>animation node</a>'s <a
     title="animation node playback rate">playback rate</a> property.
@@ -5606,14 +5602,14 @@ dictionary AnimationTimingProperties {
     See the description of the <code>playbackRate</code> attribute
     on the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>direction</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>direction</dfn>
     <span member-info for=AnimationTimingProperties/direction></span>
 ::  The <a>playback direction</a> of the <a>animation node</a>.
 
     See the description of the <code>direction</code> attribute
     on the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=AnimationTimingProperties>easing</dfn>
+:   <dfn dict-member for=AnimationTimingProperties>easing</dfn>
     <span member-info for=AnimationTimingProperties/easing></span>
 ::  The <a>timing function</a> used to scale the time to produce
     easing effects.
@@ -6606,17 +6602,17 @@ constructor by providing a {{KeyframeEffectOptions}} object.
 
 <div class="attributes">
 
-:   <dfn attribute for=KeyframeEffectOptions>name</dfn>
+:   <dfn dict-member for=KeyframeEffectOptions>name</dfn>
     <span member-info for=KeyframeEffectOptions/name></span>
 ::  The value to set for the {{AnimationEffect}}'s {{AnimationEffect/name}}
     property.
 
-:   <dfn attribute for=KeyframeEffectOptions>iterationComposite</dfn>
+:   <dfn dict-member for=KeyframeEffectOptions>iterationComposite</dfn>
     <span member-info for=KeyframeEffectOptions/iterationComposite></span>
 ::  The <a>iteration composite operation</a> used to define the way
     animation values build from iteration to iteration.
 
-:   <dfn attribute for=KeyframeEffectOptions>composite</dfn>
+:   <dfn dict-member for=KeyframeEffectOptions>composite</dfn>
     <span member-info for=KeyframeEffectOptions/composite></span>
 ::  The <a>composite operation</a> used to composite this
     animation with the <a>animation stack</a>, as specified by one
@@ -6624,7 +6620,7 @@ constructor by providing a {{KeyframeEffectOptions}} object.
     This is used for all <a>keyframes</a> that do not specify
     a <a>composite operation</a>.
 
-:   <dfn attribute for=KeyframeEffectOptions>spacing</dfn>
+:   <dfn dict-member for=KeyframeEffectOptions>spacing</dfn>
     <span member-info for=KeyframeEffectOptions/spacing></span>
 ::  The <a title="keyframe spacing mode">spacing mode</a> to apply
     to this <a>animation effect</a>'s <a>keyframes</a>.
@@ -6708,7 +6704,7 @@ dictionary Keyframe {
 
 <div class='attributes'>
 
-:   <dfn attribute for=Keyframe>offset</dfn>
+:   <dfn dict-member for=Keyframe>offset</dfn>
     <span member-info for=Keyframe/offset></span>
 ::  The <a>keyframe offset</a> of the <a>keyframe</a> specified as
     a number between 0.0 and 1.0 inclusive or <code>null</code>.
@@ -6721,7 +6717,7 @@ dictionary Keyframe {
     should be positioned using the <a>keyframe animation effect</a>'s
     <a>keyframe spacing mode</a>.
 
-:   <dfn attribute for=Keyframe>easing</dfn>
+:   <dfn dict-member for=Keyframe>easing</dfn>
     <span member-info for=Keyframe/easing></span>
 
 ::  The <a>timing function</a> used to transform the progress of time
@@ -6731,7 +6727,7 @@ dictionary Keyframe {
     is identical to that defined for the <code>easing</code> attribute
     of the {{AnimationTiming}} interface.
 
-:   <dfn attribute for=Keyframe>composite</dfn>
+:   <dfn dict-member for=Keyframe>composite</dfn>
     <span member-info for=Keyframe/composite></span>
 
 ::  The <a>composite operation</a> used to combine the values
@@ -6898,7 +6894,7 @@ dictionary ComputedKeyframe : Keyframe {
 
 <div class='attributes'>
 
-:   <dfn attribute for=ComputedKeyframe>computedOffset</dfn>
+:   <dfn dict-member for=ComputedKeyframe>computedOffset</dfn>
     <span member-info for=ComputedKeyframe/computedOffset></span>
 ::  The <a>keyframe offset</a> calculated for this <a>keyframe</a> as
     a result of applying the spacing procedure defined in
@@ -7015,33 +7011,33 @@ dictionary MotionPathEffectOptions {
 };
 </pre>
 
-:   <dfn attribute for='MotionPathEffectOptions'>autoRotate</dfn>
+:   <dfn dict-member for='MotionPathEffectOptions'>autoRotate</dfn>
     <span member-info for='MotionPathEffectOptions/autoRotate'></span>
 ::  The <a>automatic rotation flag</a> setting for the generated
     effect.
 
-:   <dfn attribute for='MotionPathEffectOptions'>angle</dfn>
+:   <dfn dict-member for='MotionPathEffectOptions'>angle</dfn>
     <span member-info for='MotionPathEffectOptions/angle'></span>
 ::  The <a>rotation angle</a> for the generated effect.
 
-:   <dfn attribute for=MotionPathEffectOptions>name</dfn>
+:   <dfn dict-member for=MotionPathEffectOptions>name</dfn>
     <span member-info for=MotionPathEffectOptions/name></span>
 ::  The value to set for the {{AnimationEffect}}'s {{AnimationEffect/name}}
     property.
 
-:   <dfn attribute for='MotionPathEffectOptions'>iterationComposite</dfn>
+:   <dfn dict-member for='MotionPathEffectOptions'>iterationComposite</dfn>
     <span member-info for='MotionPathEffectOptions/iterationComposite'></span>
 ::  The <a>iteration composite operation</a> used to define the way
     animation values build from iteration to iteration.
 
-:   <dfn attribute for='MotionPathEffectOptions'>composite</dfn>
+:   <dfn dict-member for='MotionPathEffectOptions'>composite</dfn>
     <span member-info for='MotionPathEffectOptions/composite'></span>
 ::  The <a>composite operation</a> used to composite this
     <a>animation effect</a> with the <a>animation stack</a>, as
     specified by one of the <a>CompositeOperation</a> enumeration
     values.
 
-:   <dfn attribute for='MotionPathEffectOptions'>spacing</dfn>
+:   <dfn dict-member for='MotionPathEffectOptions'>spacing</dfn>
     <span member-info for='MotionPathEffectOptions/spacing'></span>
 ::  The <a title="keyframe spacing mode">spacing mode</a> to apply
     to this <a>motion path animation effect</a>.


### PR DESCRIPTION
- convert 'attribute' type to 'dict-member' for members of IDL
  dictionaries.
- Remove start-of-line '+' as markdown now thinks this is a list.
