### PR TITLE
CSS Property 'offset' is IDL attribute 'cssOffset'

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -6390,6 +6390,9 @@ The <dfn>animation property name to IDL attribute name</dfn> algorithm for
 1.  If <var>property</var> refers to the CSS 'float' property,
     return the string "cssFloat".
 
+1.  If <var>property</var> refers to the CSS 'offset' property,
+    return the string "cssOffset".
+
 1.  Otherwise, return the result of applying the <a>CSS property to IDL
     attribute</a> algorithm [[!CSSOM]] to <var>property</var>.
 
@@ -6401,6 +6404,9 @@ The <dfn>IDL attribute name to animation property name</dfn> algorithm for
 
 1.  If <var>attribute</var> is the string "cssFloat", then return
     an animation property representing the CSS 'float' property.
+
+1.  If <var>attribute</var> is the string "cssOffset", then return
+    an animation property representing the CSS 'offset' property.
 
 1.  Otherwise, return the result of applying the <a>IDL attribute to CSS
     property</a> algorithm [[!CSSOM]] to <var>attribute</var>.

--- a/Overview.bs
+++ b/Overview.bs
@@ -7443,7 +7443,10 @@ title="Application Programming Interface">API</abbr> defined in
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 
-Thank you to Michiel &ldquo;Pomax&rdquo; Kamermans for help with the
+Thank you to Steve Block, Michael Giuffrida, Ryan Seys, and Eric Willigers
+for their contributions to this specification.
+
+Thank you also to Michiel &ldquo;Pomax&rdquo; Kamermans for help with the
 equations for a proposed smooth timing function although this feature
 has been deferred to a subsequent specification.
 
@@ -7465,6 +7468,9 @@ The following changes have been made since the <a
     accommodate timelines that change direction.
 *   Dropped keyframe spacing, distance calculation, and retention of invalid
     keyframe property values.
+*   Added special handling to allow animating the 'offset' property from the
+    programming interface using <code>cssOffset</code> to avoid conflict with
+    the attribute name used to specify keyframe offsets.
 
 <!-- @endif -->
 


### PR DESCRIPTION
Like 'float', we can't use the name 'offset' as that already has
another meaning. So, like 'cssFloat', we use 'cssOffset' instead.

Discussed in FXTF issue and on blink-dev.
https://github.com/w3c/fxtf-drafts/issues/51#issuecomment-280957557
https://groups.google.com/a/chromium.org/d/msg/blink-dev/_DPl-JG6bV8/HXkK-CwfEQAJ