### PR TITLE
Ask for web-platform-tests in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributions to this repository are intended to become part of Recommendation-t
 [Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
 in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
-If you are not the sole contributor to a contribution (pull request), please identify all 
+If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request comment.
 
 To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
@@ -18,5 +18,14 @@ If you added a contributor by mistake, you can remove them in a comment with:
 -@github_username
 ```
 
-If you are making a pull request on behalf of someone else but you had no part in designing the 
+If you are making a pull request on behalf of someone else but you had no part in designing the
 feature, you can remove yourself with the above syntax.
+
+# Tests
+
+For normative changes, a corresponding
+[web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. Typically,
+both PRs will be merged at the same time. Note that a test change that contradicts the spec should
+not be merged before the corresponding spec change. If testing is not practical, please explain why
+and if appropriate [file an issue](https://github.com/w3c/web-platform-tests/issues/new) to follow
+up later. Add the `type:untestable` or `type:missing-coverage` label as appropriate.


### PR DESCRIPTION
The wording is the same as in:
https://github.com/w3c/IndexedDB/blob/master/CONTRIBUTING.md#tests
https://github.com/w3c/pointerlock/blob/gh-pages/CONTRIBUTING.md#tests

Which was adapted from the following documents:
https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md#tests
https://github.com/whatwg/meta/blob/master/TEAM.md
https://github.com/w3c/ServiceWorker/blob/master/CONTRIBUTING.md
https://github.com/w3c/web-performance/blob/gh-pages/CONTRIBUTING.md#test-driven